### PR TITLE
Fix threaded_rtmp_server example

### DIFF
--- a/examples/threaded_rtmp_server/src/connection.rs
+++ b/examples/threaded_rtmp_server/src/connection.rs
@@ -31,7 +31,6 @@ impl From<io::Error> for ConnectionError {
 }
 
 pub struct Connection {
-    pub connection_id: Option<usize>,
     writer: Sender<Vec<u8>>,
     reader: Receiver<ReadResult>,
     handshake: Handshake,
@@ -47,7 +46,6 @@ impl Connection {
         start_result_reader(result_sender, &socket);
 
         Connection {
-            connection_id: None,
             writer: byte_sender,
             reader: result_receiver,
             handshake: Handshake::new(PeerType::Server),

--- a/examples/threaded_rtmp_server/src/main.rs
+++ b/examples/threaded_rtmp_server/src/main.rs
@@ -42,7 +42,6 @@ fn handle_connections(connection_receiver: Receiver<TcpStream>) {
             Ok(stream) => {
                 let mut connection = Connection::new(stream);
                 let id = connections.insert(connection);
-                connection.connection_id = Some(id);
                 connection_ids.insert(id);
 
                 println!("Connection {} started", id);


### PR DESCRIPTION
`examples/threaded_rtmp_server` currently fails to compile on master with this error:

```
error[E0382]: assign to part of moved value: `connection`
  --> examples/threaded_rtmp_server/src/main.rs:45:17
   |
43 |                 let mut connection = Connection::new(stream);
   |                     -------------- move occurs because `connection` has type `connection::Connection`, which does not implement the `Copy` trait
44 |                 let id = connections.insert(connection);
   |                                             ---------- value moved here
45 |                 connection.connection_id = Some(id);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ value partially assigned here after move
```

It doesn't look like the `connection_id` field on `Connection` is still in use, so I have removed it to fix the build.