### PR TITLE
use timestamp_field instead of timestamp_delta for type3 header fixin…

### DIFF
--- a/rtmp/src/chunk_io/chunk_header.rs
+++ b/rtmp/src/chunk_io/chunk_header.rs
@@ -12,7 +12,7 @@ pub enum ChunkHeaderFormat {
 pub struct ChunkHeader {
     pub chunk_stream_id: u32,
     pub timestamp: RtmpTimestamp,
-    pub timestamp_delta: u32,
+    pub timestamp_field: u32,
     pub message_length: u32,
     pub message_type_id: u8,
     pub message_stream_id: u32,
@@ -24,7 +24,7 @@ impl ChunkHeader {
         ChunkHeader {
             chunk_stream_id: 0,
             timestamp: RtmpTimestamp::new(0),
-            timestamp_delta: 0,
+            timestamp_field: 0,
             message_length: 0,
             message_type_id: 0,
             message_stream_id: 0,


### PR DESCRIPTION
I think my last pull request for fixing type 3 extended timestamp was not very rigorous.

First, i use  (self.current_header.timestamp >= MAX_INITIAL_TIMESTAMP && self.current_header.timestamp_delta == 0) indicating the previous header was type 0, it's not rigorous as the delta timestamp from rtmp clent maybe zero.

Second, we should not apply  extended timestamp of  type 3 chunk if the type 3 chunk is not the first chunk of a message.

 Maybe we should use timestamp_field which means the 3 bytes timestamp field of message header, then we could know if we will read or write the extended timestamp.