### PR TITLE
Add optional tcUrl field for request_connection

### DIFF
--- a/examples/mio_rtmp_server/src/server.rs
+++ b/examples/mio_rtmp_server/src/server.rs
@@ -66,7 +66,6 @@ enum PushState {
 struct PushClient {
     session: Option<ClientSession>,
     connection_id: Option<usize>,
-    push_host: String,
     push_app: String,
     push_source_stream: String,
     push_target_stream: String,
@@ -106,7 +105,6 @@ impl Server {
             &Some(ref options) => {
                 Some(PushClient {
                     push_app: options.app.clone(),
-                    push_host: options.host.clone(),
                     push_source_stream: options.source_stream.clone(),
                     push_target_stream: options.target_stream.clone(),
                     connection_id: None,
@@ -866,9 +864,7 @@ impl Server {
                     // to initiate the connection process
                     client.state = PushState::Connecting;
 
-                    let tc_url = format!("rtmp://{}:1935/{}", client.push_host, client.push_app);
-
-                    let result = match client.session.as_mut().unwrap().request_srs_connection(client.push_app.clone(), tc_url) {
+                    let result = match client.session.as_mut().unwrap().request_connection(client.push_app.clone()) {
                         Ok(result) => result,
                         Err(error) => {
                             println!("Failed to request connection for push client: {:?}", error);

--- a/examples/mio_rtmp_server/src/server.rs
+++ b/examples/mio_rtmp_server/src/server.rs
@@ -66,6 +66,7 @@ enum PushState {
 struct PushClient {
     session: Option<ClientSession>,
     connection_id: Option<usize>,
+    push_host: String,
     push_app: String,
     push_source_stream: String,
     push_target_stream: String,
@@ -105,6 +106,7 @@ impl Server {
             &Some(ref options) => {
                 Some(PushClient {
                     push_app: options.app.clone(),
+                    push_host: options.host.clone(),
                     push_source_stream: options.source_stream.clone(),
                     push_target_stream: options.target_stream.clone(),
                     connection_id: None,
@@ -864,7 +866,9 @@ impl Server {
                     // to initiate the connection process
                     client.state = PushState::Connecting;
 
-                    let result = match client.session.as_mut().unwrap().request_connection(client.push_app.clone()) {
+                    let tc_url = format!("rtmp://{}:1935/{}", client.push_host, client.push_app);
+
+                    let result = match client.session.as_mut().unwrap().request_srs_connection(client.push_app.clone(), tc_url) {
                         Ok(result) => result,
                         Err(error) => {
                             println!("Failed to request connection for push client: {:?}", error);

--- a/rtmp/src/sessions/client/config.rs
+++ b/rtmp/src/sessions/client/config.rs
@@ -5,6 +5,7 @@ pub struct ClientSessionConfig {
     pub playback_buffer_length_ms: u32,
     pub window_ack_size: u32,
     pub chunk_size: u32,
+    pub tc_url: Option<String>,
 }
 
 impl ClientSessionConfig {
@@ -15,6 +16,7 @@ impl ClientSessionConfig {
             playback_buffer_length_ms: 2_000,
             window_ack_size: 2_500_000,
             chunk_size: 4096,
+            tc_url: None
         }
     }
 }

--- a/rtmp/src/sessions/client/mod.rs
+++ b/rtmp/src/sessions/client/mod.rs
@@ -186,6 +186,40 @@ impl ClientSession {
         Ok(ClientSessionResult::OutboundResponse(packet))
     }
 
+    // Adding extra required amf0 values so that talking to SRS is possible - horrible duplication might not be required, but this is the best way I can find for now
+    pub fn request_srs_connection(&mut self, app_name: String, tc_url: String) -> Result<ClientSessionResult, ClientSessionError> {
+        match self.current_state {
+            ClientState::Disconnected => (),
+            _ => {
+                let kind = ClientSessionErrorKind::CantConnectWhileAlreadyConnected;
+                return Err(ClientSessionError {kind});
+            },
+        }
+
+        let transaction_id = self.get_next_transaction_id();
+        let transaction = OutstandingTransaction::ConnectionRequested {app_name: app_name.clone()};
+        self.outstanding_transactions.insert(transaction_id, transaction);
+        
+        let mut properties = HashMap::new();
+        properties.insert("app".to_string(), Amf0Value::Utf8String(app_name));
+        properties.insert("flashVer".to_string(), Amf0Value::Utf8String(self.config.flash_version.clone()));
+        properties.insert("objectEncoding".to_string(), Amf0Value::Number(0.0));
+        properties.insert("tcUrl".to_string(), Amf0Value::Utf8String(tc_url));
+
+
+        let message = RtmpMessage::Amf0Command {
+            command_name: "connect".to_string(),
+            command_object: Amf0Value::Object(properties),
+            additional_arguments: vec![],
+            transaction_id: transaction_id as f64,
+        };
+
+        let payload = message.into_message_payload(self.get_epoch(), 0)?;
+        let packet = self.serializer.serialize(&payload, false, false)?;
+
+        Ok(ClientSessionResult::OutboundResponse(packet))
+    }
+
     /// Starts the process of requesting playback on the server for the specified stream key.  An
     /// event will be raised when the request is accepted or rejected.  Once accepted we will
     /// receive audio, video, and metadata information via `ClientSessionEvent`s.


### PR DESCRIPTION
Hi, thanks for this library, it's extremely useful! 

I've been trying to use it as a basis for a sort of proxy for incoming RTMP connections and I ran into a surprising issue. Our push target RTMP server is SRS (https://github.com/ossrs/srs) and using the example `mio_rtmp_server` to test against, it gave this response:
```
serve error code=2005 : rtmp connect tcUrl : invalid request without tcUrl
```
I assume this isn't a hard requirement as part of the RTMP specification that your library follows, but I have found references to it here https://linux.die.net/man/8/rtmpgw and here https://en.wikipedia.org/wiki/Real-Time_Messaging_Protocol#Protocol, which suggests it's diffuse.

I initially "vendored in" this library by copying it and making the changes I needed within my own project, but it would be great if your library could offer this additional feature as it seems I can't use it without it. I couldn't find a nice way to work around Rust's visibility rules to make the changes unobtrusively from my code. I afraid I'm fairly new to Rust so it could be there's a nicer way that I can't see, but since most of rtmp::sessions::client is private, I thought it was unlikely I could monkey-patch anything or call lower-level functions to make a bespoke Amf0Command with the added field.

So this is my simple proposal for adding this functionality. I kept it as optional so that it wouldn't break backwards compatibility. If it's not idiomatic Rust please let me know, I'd like to use this as an opportunity to learn.