### PR TITLE
Serialization of larger payloads can lead to incorrect chunks

### DIFF
--- a/examples/mio_rtmp_server/src/connection.rs
+++ b/examples/mio_rtmp_server/src/connection.rs
@@ -10,8 +10,8 @@ use rml_rtmp::handshake::{Handshake, PeerType, HandshakeProcessResult};
 use rml_rtmp::chunk_io::{Packet};
 
 const BUFFER_SIZE: usize = 4096;
-const SOCKET_RECEIVE_BUFFER_SIZE: usize = 1 * 1024 * 1024;
-const SOCKET_SEND_BUFFER_SIZE: usize = 1 * 1024 * 1024;
+const SOCKET_RECEIVE_BUFFER_SIZE: usize = 4 * 1024 * 1024;
+const SOCKET_SEND_BUFFER_SIZE: usize = 4 * 1024 * 1024;
 
 pub enum ReadResult {
     HandshakingInProgress,

--- a/examples/mio_rtmp_server/src/connection.rs
+++ b/examples/mio_rtmp_server/src/connection.rs
@@ -64,7 +64,6 @@ pub struct Connection {
 
 impl Connection {
     pub fn new(socket: TcpStream, count: usize, log_debug_logic: bool, is_inbound_connection: bool) -> Connection {
-        socket.set_nodelay(true).expect("Could not set nodelay!");
         socket.set_recv_buffer_size(SOCKET_RECEIVE_BUFFER_SIZE).expect("Could not set recv buffer size");
         socket.set_send_buffer_size(SOCKET_SEND_BUFFER_SIZE).expect("Could not set send buffer size");
 


### PR DESCRIPTION
This PR contains a fix for issue https://github.com/KallDrexx/rust-media-libs/issues/21. 

It contains the following changes:
- Changed the size of the socket send buffer to 4MB (from default: 87 KB)
- Changed the size of the socket receive buffer to 4MB (from default: 369 KB)
- Changed the 'write' function to 'write_all', which will fail when the buffer is not fully written. 

Gstreamer uses a default size of the TCP buffers of 2.5MB, I set the default sizes to 4 MB. 

I'm not a Rust programmer, so let me know what you would like to see changed! 