### PR TITLE
Fix extended timestamp on type 3 chunks

### DIFF
--- a/rtmp/src/chunk_io/serializer.rs
+++ b/rtmp/src/chunk_io/serializer.rs
@@ -144,7 +144,7 @@ impl ChunkSerializer {
                         //  Continued chunks should use Format Type 3.
                         //  Streaming into Twitch was breaking when a payload exceeded the max chunk size
                         //  Continued chunks may add extended timestamp, set timestamp field as previous timestamp_field
-                        header.timestamp_field = (header.timestamp - previous_header.timestamp).value;
+                        header.timestamp_field = previous_header.timestamp_field;
                         ChunkHeaderFormat::Empty
 
                     } else if previous_header.can_be_dropped {

--- a/rtmp/src/chunk_io/serializer.rs
+++ b/rtmp/src/chunk_io/serializer.rs
@@ -624,6 +624,45 @@ mod tests {
     }
 
     #[test]
+    fn message_split_extended_timestamp() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&[11_u8; 75]);
+        payload.extend_from_slice(&[22_u8; 25]);
+
+        let timestamp_value = MAX_INITIAL_TIMESTAMP + 1;
+        let message1 = MessagePayload {
+            timestamp: RtmpTimestamp::new(timestamp_value),
+            type_id: 50,
+            message_stream_id: 12,
+            data: Bytes::from(payload.clone()),
+        };
+
+        let mut serializer = ChunkSerializer::new();
+        serializer.set_max_chunk_size(75, RtmpTimestamp::new(0)).unwrap();
+
+        let packet = serializer.serialize(&message1, false, false).unwrap();
+
+        let mut cursor = Cursor::new(packet.bytes);
+        assert_eq!(cursor.read_u8().unwrap(), 6 | 0b00000000, "Unexpected csid value");
+        assert_eq!(cursor.read_u24::<BigEndian>().unwrap(), MAX_INITIAL_TIMESTAMP, "Unexpected timestamp value");
+        assert_eq!(cursor.read_u24::<BigEndian>().unwrap(), 100, "Unexpected message length value");
+        assert_eq!(cursor.read_u8().unwrap(), 50, "Unexpected type id");
+        assert_eq!(cursor.read_u32::<LittleEndian>().unwrap(), 12, "Unexpected message stream id");
+        assert_eq!(cursor.read_u32::<BigEndian>().unwrap(), timestamp_value, "Unexpected extended timestamp value");
+
+        let mut payload_bytes = [0_u8; 75];
+        let bytes_read = cursor.read(&mut payload_bytes[..]).unwrap();
+        assert_eq!(bytes_read, 75, "Unexpected payload bytes read");
+        assert_eq!(&payload_bytes[..bytes_read], &([11_u8; 75])[..], "Unexpected payload contents");
+
+        assert_eq!(cursor.read_u8().unwrap(), 6 | 0b11000000, "Unexpected 2nd csid value");
+        assert_eq!(cursor.read_u32::<BigEndian>().unwrap(), timestamp_value, "Unexpected extended timestamp value on second chunk");
+        let bytes_read = cursor.read(&mut payload_bytes[..]).unwrap();
+        assert_eq!(bytes_read, 25, "Unexpected 2nd payload bytes read");
+        assert_eq!(&payload_bytes[..bytes_read], &([22_u8; 25])[..], "Unexpected 2nd payload contents");
+    }
+
+    #[test]
     fn changing_size_returns_set_chunk_size_outbound_message() {
         let mut serializer = ChunkSerializer::new();
         let packet = serializer.set_max_chunk_size(75, RtmpTimestamp::new(152)).unwrap();


### PR DESCRIPTION
I was getting spammed with messages from gstreamer when pulling from my RTMP server after a period of time, e.g:
```
Type 3 extended timestamp does not match expected timestamp (want 250836763 got 2960806818)
```

After some reading of the RTMP spec and understanding the serialization code, I've come to this fix. The comment above it suggests this was probably what was originally intended, as the code currently ends up always being calculated as 0 as far as I can tell.

This is only an issue with longer running streams, and actually gstreamer didn't seem to care all that much other than the gigabytes of warnings it was logging. I have this fix deployed on our servers but it hasn't been enough time to trigger this case to 100% confirm its fixed, but it seems correct to me and I have added a test to ensure the extended timestamp is added to the type 3 chunks as desired.