### PR TITLE
Added support AMF0 strict array type

### DIFF
--- a/amf0/src/lib.rs
+++ b/amf0/src/lib.rs
@@ -50,6 +50,7 @@ pub enum Amf0Value {
     Boolean(bool),
     Utf8String(String),
     Object(HashMap<String, Amf0Value>),
+    StrictArray(Vec<Amf0Value>),
     Null,
     Undefined,
 }
@@ -93,5 +94,6 @@ mod markers {
     pub const UNDEFINED_MARKER: u8 = 6;
     pub const ECMA_ARRAY_MARKER: u8 = 8;
     pub const OBJECT_END_MARKER: u8 = 9;
+    pub const STRICT_ARRAY_MARKER: u8 = 10;
     pub const UTF_8_EMPTY_MARKER: u16 = 0;
 }


### PR DESCRIPTION
Hi,  I found that library not support AMF0 Strict Array Type and by this reason it fail playing stream from Wowza Media Server (if stream transcoded). Added support for encoding and decoding and checked that it works with real application.