### PR TITLE
ServerSession:Introduce `finish_playing()`

### DIFF
--- a/rtmp/src/sessions/server/active_stream.rs
+++ b/rtmp/src/sessions/server/active_stream.rs
@@ -11,6 +11,8 @@ pub enum StreamState {
     Playing {
         stream_key: String,
     },
+
+    Completed,
 }
 
 pub struct ActiveStream {


### PR DESCRIPTION
Previously, a playing server-session had no way to signal End Of Stream in an "expected" manner. Cutting the TCP session was possible, leaving the client without a good portable way to know if the disconnect was intentional, or the result of a network-disconnection.

The specs are light with expected behavior around stream-finish. FFmpeg seems to do it all wrong, sending an "FCunpublish" command, which is both non-standard, and intended for the RTMP-_client_ anyway. However, piecing together https://rtmp.veriskope.com/docs/spec/: "The server sends NetStream status updates to the client using the “onStatus” command", and https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/NetStream.html "You can use this property to trigger actions in your code when a NetStream object has switched from one stream to another stream in a playlist (as indicated by the information object NetStream.Play.Switch) or when a NetStream object has played to the end (as indicated by the information object NetStream.Play.Complete).", it seems this is a way to signal that is at least referencable through specification.