### PR TITLE
Updated setting connection ID in Connection

### DIFF
--- a/examples/threaded_rtmp_server/src/connection.rs
+++ b/examples/threaded_rtmp_server/src/connection.rs
@@ -31,7 +31,7 @@ impl From<io::Error> for ConnectionError {
 }
 
 pub struct Connection {
-    pub connection_id: Option<usize>,
+    pub connection_id: usize,
     writer: Sender<Vec<u8>>,
     reader: Receiver<ReadResult>,
     handshake: Handshake,
@@ -39,7 +39,7 @@ pub struct Connection {
 }
 
 impl Connection {
-    pub fn new(socket: TcpStream) -> Connection {
+    pub fn new(connection_id: usize, socket: TcpStream) -> Connection {
         let (byte_sender, byte_receiver) = channel();
         let (result_sender, result_receiver) = channel();
 
@@ -47,7 +47,7 @@ impl Connection {
         start_result_reader(result_sender, &socket);
 
         Connection {
-            connection_id: None,
+            connection_id,
             writer: byte_sender,
             reader: result_receiver,
             handshake: Handshake::new(PeerType::Server),

--- a/examples/threaded_rtmp_server/src/main.rs
+++ b/examples/threaded_rtmp_server/src/main.rs
@@ -38,12 +38,11 @@ fn handle_connections(connection_receiver: Receiver<TcpStream>) {
             Err(TryRecvError::Disconnected) => panic!("Connection receiver closed"),
             Err(TryRecvError::Empty) => (),
             Ok(stream) => {
-                let connection = Connection::new(stream);
-                let id = connections.insert(connection);
-                let connection = connections.get_mut(id).unwrap();
-                connection.connection_id = Some(id);
+                let entry = connections.vacant_entry();
+                let connection_id = entry.key();
+                entry.insert(Connection::new(connection_id, stream));
 
-                println!("Connection {} started", id);
+                println!("Connection {connection_id} started");
             }
         }
 


### PR DESCRIPTION
Replaces the `connection_id: Option<usize>` with `connection_id: usize` in `Connection` though i am note sure why the connection ID is stored in the `Connection` as it is never used. So removing it all together would also be an option...