### PR TITLE
Multiple small fixes / improvements

### DIFF
--- a/amf0/src/deserialization.rs
+++ b/amf0/src/deserialization.rs
@@ -81,7 +81,7 @@ fn parse_bool<R: Read>(bytes: &mut R) -> Result<Amf0Value, Amf0DeserializationEr
 fn parse_string<R: Read>(bytes: &mut R) -> Result<Amf0Value, Amf0DeserializationError> {
     let length = bytes.read_u16::<BigEndian>()?;
     let mut buffer: Vec<u8> = vec![0_u8; length as usize];
-    bytes.read(&mut buffer)?;
+    bytes.read_exact(&mut buffer)?;
 
     let value = String::from_utf8(buffer)?;
     Ok(Amf0Value::Utf8String(value))
@@ -148,7 +148,7 @@ fn parse_object_property<R: Read>(
     }
 
     let mut label_buffer = vec![0; label_length as usize];
-    bytes.read(&mut label_buffer)?;
+    bytes.read_exact(&mut label_buffer)?;
 
     let label = String::from_utf8(label_buffer)?;
 

--- a/amf0/src/serialization.rs
+++ b/amf0/src/serialization.rs
@@ -20,25 +20,25 @@ pub fn serialize(values: &Vec<Amf0Value>) -> Result<Vec<u8>, Amf0SerializationEr
 
 fn serialize_value(value: &Amf0Value, bytes: &mut Vec<u8>) -> Result<(), Amf0SerializationError> {
     match *value {
-        Amf0Value::Boolean(ref val) => Ok(serialize_bool(&val, bytes)),
+        Amf0Value::Boolean(val) => Ok(serialize_bool(val, bytes)),
         Amf0Value::Null => Ok(serialize_null(bytes)),
         Amf0Value::Undefined => Ok(serialize_undefined(bytes)),
-        Amf0Value::Number(ref val) => serialize_number(&val, bytes),
-        Amf0Value::Utf8String(ref val) => serialize_string(&val, bytes),
-        Amf0Value::Object(ref val) => serialize_object(&val, bytes),
-        Amf0Value::StrictArray(ref val) => serialize_strict_array(&val, bytes),
+        Amf0Value::Number(val) => serialize_number(val, bytes),
+        Amf0Value::Utf8String(ref val) => serialize_string(val, bytes),
+        Amf0Value::Object(ref val) => serialize_object(val, bytes),
+        Amf0Value::StrictArray(ref val) => serialize_strict_array(val, bytes),
     }
 }
 
-fn serialize_number(value: &f64, bytes: &mut Vec<u8>) -> Result<(), Amf0SerializationError> {
+fn serialize_number(value: f64, bytes: &mut Vec<u8>) -> Result<(), Amf0SerializationError> {
     bytes.push(markers::NUMBER_MARKER);
-    bytes.write_f64::<BigEndian>(value.clone())?;
+    bytes.write_f64::<BigEndian>(value)?;
     Ok(())
 }
 
-fn serialize_bool(value: &bool, bytes: &mut Vec<u8>) {
+fn serialize_bool(value: bool, bytes: &mut Vec<u8>) {
     bytes.push(markers::BOOLEAN_MARKER);
-    bytes.push((value.clone()) as u8);
+    bytes.push(value as u8);
 }
 
 fn serialize_string(value: &String, bytes: &mut Vec<u8>) -> Result<(), Amf0SerializationError> {

--- a/examples/mio_rtmp_server/src/connection.rs
+++ b/examples/mio_rtmp_server/src/connection.rs
@@ -175,7 +175,7 @@ impl Connection {
                         None => (),
                         Some(ref mut logs) => {
                             logs.rtmp_input_file
-                                .write(&read_buffer[..byte_count])
+                                .write_all(&read_buffer[..byte_count])
                                 .unwrap();
                         }
                     },
@@ -226,7 +226,7 @@ impl Connection {
                     match self.debug_log_files {
                         None => (),
                         Some(ref mut logs) => {
-                            logs.rtmp_output_file.write(&bytes).unwrap();
+                            logs.rtmp_output_file.write_all(&bytes).unwrap();
                         }
                     }
                 }

--- a/examples/threaded_rtmp_server/src/main.rs
+++ b/examples/threaded_rtmp_server/src/main.rs
@@ -67,7 +67,7 @@ fn handle_connections(connection_receiver: Receiver<TcpStream>) {
                     ReadResult::NoBytesReceived => (),
                     ReadResult::HandshakingInProgress => (),
                     ReadResult::BytesReceived { buffer, byte_count } => {
-                        let mut server_results =
+                        let server_results =
                             match server.bytes_received(connection_id, &buffer[..byte_count]) {
                                 Ok(results) => results,
                                 Err(error) => {
@@ -77,7 +77,7 @@ fn handle_connections(connection_receiver: Receiver<TcpStream>) {
                                 }
                             };
 
-                        for result in server_results.drain(..) {
+                        for result in server_results.into_iter() {
                             match result {
                                 ServerResult::OutboundPacket {
                                     target_connection_id,
@@ -98,7 +98,7 @@ fn handle_connections(connection_receiver: Receiver<TcpStream>) {
             }
         }
 
-        for (connection_id, packet) in packets_to_write.drain(..) {
+        for (connection_id, packet) in packets_to_write.into_iter() {
             let connection = connections.get_mut(connection_id).unwrap();
             connection.write(packet.bytes);
         }

--- a/examples/threaded_rtmp_server/src/server.rs
+++ b/examples/threaded_rtmp_server/src/server.rs
@@ -640,8 +640,8 @@ impl Server {
             let should_send_to_client = match data_type {
                 ReceivedDataType::Video => {
                     client.has_received_video_keyframe
-                        || (is_video_sequence_header(data.clone())
-                            || is_video_keyframe(data.clone()))
+                        || is_video_sequence_header(data.clone())
+                        || is_video_keyframe(data.clone())
                 }
 
                 ReceivedDataType::Audio => {

--- a/rtmp/src/chunk_io/serializer.rs
+++ b/rtmp/src/chunk_io/serializer.rs
@@ -293,7 +293,7 @@ fn add_extended_timestamp(
 }
 
 fn add_message_payload(bytes: &mut dyn Write, data: &[u8]) -> Result<(), ChunkSerializationError> {
-    bytes.write(data)?;
+    bytes.write_all(data)?;
     Ok(())
 }
 

--- a/tools/handshake-tester/src/main.rs
+++ b/tools/handshake-tester/src/main.rs
@@ -24,7 +24,7 @@ fn act_as_client(host_address: &str) {
     let mut stream = TcpStream::connect(host_address).unwrap();
     let mut handshake = Handshake::new(PeerType::Client);
     let c0_and_c1 = handshake.generate_outbound_p0_and_p1().unwrap();
-    stream.write(&c0_and_c1).unwrap();
+    stream.write_all(&c0_and_c1).unwrap();
 
     let mut read_buffer = [0_u8; 1024];
 
@@ -43,7 +43,7 @@ fn act_as_client(host_address: &str) {
             };
 
         if response_bytes.len() > 0 {
-            stream.write(&response_bytes).unwrap();
+            stream.write_all(&response_bytes).unwrap();
         }
 
         if is_finished {
@@ -80,7 +80,7 @@ fn act_as_server() {
                 };
 
             if response_bytes.len() > 0 {
-                stream.write(&response_bytes).unwrap();
+                stream.write_all(&response_bytes).unwrap();
             }
 
             if is_finished {


### PR DESCRIPTION
Some random improvements to the code, and a couple small fixes, that could result in unexpected behavior. Although as  the write and read functions are called on buffers, they will most likely always return the expected number of bytes.

You might want to run Clippy some times. These changes should fix all the errors, but there are a lot of warnings left. Most of them about creating references when they are not needed.