### PR TITLE
Lowercase check on publish command mode

### DIFF
--- a/rtmp/src/sessions/server/mod.rs
+++ b/rtmp/src/sessions/server/mod.rs
@@ -735,7 +735,7 @@ impl ServerSession {
         };
 
         let mode = match arguments.remove(0) {
-            Amf0Value::Utf8String(raw_mode) => match raw_mode.as_ref() {
+            Amf0Value::Utf8String(raw_mode) => match raw_mode.to_lowercase().as_ref() {
                 "live" => PublishMode::Live,
                 "append" => PublishMode::Append,
                 "record" => PublishMode::Record,


### PR DESCRIPTION
Some clients in the wild sends an uppercase publishing type when publishing.
Instead of rejecting, we could compare with the lowercase raw value.
